### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kfind.json
+++ b/org.kde.kfind.json
@@ -12,8 +12,10 @@
         "--filesystem=host",
         "--device=dri"
     ],
-    "cleanup": [
-        "/share/man"
+     "cleanup": [
+        "/share/doc",
+        "/share/man",
+        "/share/qlogging-categories6"
     ],
     "modules": [
         {


### PR DESCRIPTION
The installed size reduced from 845.3 kB to 626.2 kB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.