### PR TITLE
Drop only-show-in=KDE tag to make app visible on other DEs

### DIFF
--- a/org.kde.kfind.json
+++ b/org.kde.kfind.json
@@ -19,6 +19,9 @@
         {
             "name": "kfind",
             "buildsystem": "cmake-ninja",
+            "post-install": [
+                "desktop-file-edit --remove-only-show-in=KDE /app/share/applications/${FLATPAK_ID}.desktop"
+            ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Fixes: https://github.com/flathub/org.kde.kfind/issues/60